### PR TITLE
Only Use Relevant LogSources when Running Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.so
 *.dylib
 
+# IDE Directories
+.idea
+
 # Test binary, built with `go test -c`
 *.test
 


### PR DESCRIPTION
This PR ensures we only use logsources that are relevant to the alert in question. Without this, field names from other log sources can be used, if they are conflicting. 

The PR also now detects if there is not an applicable log source passed in for the rule. 